### PR TITLE
Add CircleCI build configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/contentful/gofog
+    steps:
+      - checkout
+      - run:
+          name: Installing dep
+          command: |
+            go get -d -u github.com/golang/dep/cmd/dep
+            go install github.com/golang/dep/cmd/dep
+      - run:
+          name: Fetching dependencies
+          command: dep ensure
+      - run:
+          name: Build binary
+          command: go build
+      - run:
+          name: Generate checksum
+          command: sha512sum gofog > gofog.sum
+      - run:
+          name: Fetch upload tools
+          command: |
+            sudo apt-get update
+            sudo apt-get install awscli 
+      - deploy:
+          name: Upload to S3
+          command: |
+            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+              aws s3 cp ./gofog s3://${LAB_ASSETS_BUCKET}/gofog
+              aws s3 cp ./gofog.sum s3://${LAB_ASSETS_BUCKET}/gofog.sum
+            fi


### PR DESCRIPTION
This will currently only upload the build/checksum when changes pushed to master, but we should/could also consider uploading on tagged releases.

Let me know if the upload location should be changed.