### PR TITLE
Bake version number into binary during build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
           command: dep ensure
       - run:
           name: Build binary
-          command: go build
+          command: |
+            VERSION=$CIRCLE_BRANCH
+            if [[ "$CIRCLE_TAG" != "" ]]; then VERSION=$CIRCLE_TAG; fi
+            go build -ldflags "-X main.gofogVersion=$VERSION"
       - run:
           name: Generate checksum
           command: sha512sum gofog > gofog.sum

--- a/main.go
+++ b/main.go
@@ -7,9 +7,11 @@ import (
 	"os"
 )
 
+var gofogVersion = "unknown"
+
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "%s you need to specify a service, available services are: %s\n", os.Args[0], "ec2")
+		fmt.Fprintf(os.Stderr, "%s you need to specify a service, available services are: %s\n", os.Args[0], "ec2, sns")
 		os.Exit(1)
 	}
 	cmd := os.Args[1]
@@ -20,6 +22,9 @@ func main() {
 	case "sns":
 		sns.Run()
 		os.Exit(0)
+    case "-v":
+        fmt.Printf("Gofog version %s\n", gofogVersion)
+        os.Exit(0)
 	}
 	fmt.Sprintf("unknown command %v", cmd)
 	os.Exit(1)


### PR DESCRIPTION
Bit of a hack since it doesn't use the flags package. Let me know what you think.